### PR TITLE
feat(i18n): translate all hardcoded strings in remaining components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,19 @@ describe('myFeature', () => {
 3. Ensure type checking passes: `npm run build`
 4. Only then commit and push
 
+## Internationalization (i18n) Requirements ⚠️
+
+**IMPORTANT**: All user-facing text in UI components MUST use the translation system. Never hardcode English strings in templates or component logic.
+
+### Rules
+- Use `$t('namespace.key')` in templates
+- Use `const { t } = useI18n()` and call `t('namespace.key')` in `<script setup>`
+- Add new keys to **both** `src/i18n/locales/en.json` and `src/i18n/locales/sv.json`
+- Follow the existing namespace structure: `auth`, `nav`, `chat`, `settings`, `server`, `channel`, `voice`, `friends`, `members`, `bugs`, `common`
+- Use `common` for generic strings (loading, error, cancel, etc.) that appear across multiple components
+- For pluralization, use vue-i18n's plural syntax: `"key": "singular | plural"` and call `$t('key', count, { count })`
+- Never hardcode locale strings for date formatting — use `locale.value` from `useI18n()`
+
 ## Project Structure
 
 ```

--- a/src/components/auth/EmailVerificationBanner.vue
+++ b/src/components/auth/EmailVerificationBanner.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { resendVerification } from '@/services/emailApi'
 import { Button } from '@/components/ui/button'
 import { AlertCircle } from 'lucide-vue-next'
 
+const { t } = useI18n()
 const authStore = useAuthStore()
 const loading = ref(false)
 const cooldownSeconds = ref(0)
@@ -23,7 +25,7 @@ async function handleResend() {
 
   try {
     await resendVerification()
-    message.value = 'Verification email sent! Please check your inbox.'
+    message.value = t('auth.verificationEmailSent')
     startCooldown(300) // 5 minutes
   } catch (error: any) {
     if (error.response?.status === 429) {
@@ -32,12 +34,12 @@ async function handleResend() {
       if (match) {
         const seconds = parseInt(match[1])
         startCooldown(seconds)
-        message.value = `Please wait before requesting another email.`
+        message.value = t('auth.pleaseWaitBeforeResend')
       } else {
-        message.value = 'Too many requests. Please try again later.'
+        message.value = t('auth.tooManyRequests')
       }
     } else {
-      message.value = 'Failed to send verification email. Please try again.'
+      message.value = t('auth.failedSendVerification')
     }
   } finally {
     loading.value = false
@@ -79,8 +81,8 @@ function formatCooldown(seconds: number): string {
       <div class="flex items-center gap-3">
         <AlertCircle :size="20" />
         <div>
-          <p class="font-medium">Email verification required</p>
-          <p class="text-sm opacity-90">Please verify your email address to unlock all features.</p>
+          <p class="font-medium">{{ $t('auth.emailVerificationRequired') }}</p>
+          <p class="text-sm opacity-90">{{ $t('auth.verifyEmailSubtitle') }}</p>
         </div>
       </div>
 
@@ -93,9 +95,9 @@ function formatCooldown(seconds: number): string {
           variant="secondary"
           size="sm"
         >
-          <span v-if="loading">Sending...</span>
-          <span v-else-if="cooldownSeconds > 0">Wait {{ formatCooldown(cooldownSeconds) }}</span>
-          <span v-else>Resend Email</span>
+          <span v-if="loading">{{ $t('auth.sending') }}</span>
+          <span v-else-if="cooldownSeconds > 0">{{ $t('auth.waitCooldown', { time: formatCooldown(cooldownSeconds) }) }}</span>
+          <span v-else>{{ $t('auth.resendEmail') }}</span>
         </Button>
       </div>
     </div>

--- a/src/components/chat/ChatHeader.vue
+++ b/src/components/chat/ChatHeader.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useRoute } from 'vue-router'
+import { useI18n } from 'vue-i18n'
 import { useUiStore } from '@/stores/ui'
 import { useResponsive } from '@/composables/useResponsive'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Hash, AtSign, Menu, Users, Pin, Search } from 'lucide-vue-next'
+
+const { t } = useI18n()
 
 interface Props {
   channelName: string
@@ -54,7 +56,7 @@ const { isMobile, isTablet } = useResponsive()
               <Search class="h-5 w-5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Search</TooltipContent>
+          <TooltipContent>{{ t('common.search') }}</TooltipContent>
         </Tooltip>
         <Tooltip>
           <TooltipTrigger as-child>
@@ -67,7 +69,7 @@ const { isMobile, isTablet } = useResponsive()
               <Pin class="h-5 w-5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Pinned Messages</TooltipContent>
+          <TooltipContent>{{ t('chat.pinnedMessages') }}</TooltipContent>
         </Tooltip>
         <Tooltip v-if="!isDm">
           <TooltipTrigger as-child>
@@ -81,7 +83,7 @@ const { isMobile, isTablet } = useResponsive()
               <Users class="h-5 w-5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Toggle Member List</TooltipContent>
+          <TooltipContent>{{ t('voice.toggleMemberList') }}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/src/components/chat/PinnedMessagesPanel.vue
+++ b/src/components/chat/PinnedMessagesPanel.vue
@@ -19,7 +19,7 @@ interface Props {
 const props = defineProps<Props>()
 const emit = defineEmits<{ close: []; jumpTo: [messageId: string] }>()
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const messagesStore = useMessagesStore()
 const authStore = useAuthStore()
 const serversStore = useServersStore()
@@ -40,7 +40,7 @@ watch(() => [props.open, props.channelId], async ([open]) => {
 const pinnedMessages = messagesStore.pinnedMessages
 
 function formatDate(ts: string) {
-  return new Date(ts).toLocaleDateString('en-US', {
+  return new Date(ts).toLocaleDateString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -79,7 +79,7 @@ async function handleUnpin(messageId: string) {
     <ScrollArea class="flex-1">
       <div class="p-3 space-y-2">
         <div v-if="isLoading" class="flex items-center justify-center py-8">
-          <span class="text-sm text-muted-foreground">Loading...</span>
+          <span class="text-sm text-muted-foreground">{{ $t('common.loading') }}</span>
         </div>
 
         <div
@@ -89,7 +89,7 @@ async function handleUnpin(messageId: string) {
           <Pin class="mb-3 h-10 w-10 text-muted-foreground/30" />
           <p class="text-sm text-muted-foreground">{{ $t('chat.noPinnedMessages') }}</p>
           <p class="mt-1 text-xs text-muted-foreground/60">
-            Pin important messages to find them later
+            {{ $t('chat.pinHint') }}
           </p>
         </div>
 
@@ -119,7 +119,7 @@ async function handleUnpin(messageId: string) {
               class="h-6 px-2 text-xs"
               @click="emit('jumpTo', msg.id)"
             >
-              Jump
+              {{ $t('chat.jump') }}
             </Button>
             <Button
               v-if="isOwner || msg.author.id === authStore.user?.id"
@@ -128,7 +128,7 @@ async function handleUnpin(messageId: string) {
               class="h-6 px-2 text-xs text-destructive hover:text-destructive"
               @click="handleUnpin(msg.id)"
             >
-              Unpin
+              {{ $t('chat.unpin') }}
             </Button>
           </div>
         </div>

--- a/src/components/chat/SearchModal.vue
+++ b/src/components/chat/SearchModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import type { Message } from '@/types'
 import { messageApi } from '@/services/messageApi'
 import UserAvatar from '@/components/common/UserAvatar.vue'
@@ -11,6 +12,8 @@ import {
 } from '@/components/ui/dialog'
 import { Search, X, File, Image, Link } from 'lucide-vue-next'
 import { renderMarkdown } from '@/composables/useMarkdown'
+
+const { locale } = useI18n()
 
 interface Props {
   channelId: string
@@ -31,9 +34,9 @@ const hasSearched = ref(false)
 const activeFilter = ref<string | null>(null)
 
 const filterOptions = [
-  { key: 'file', label: 'File', icon: File },
-  { key: 'image', label: 'Image', icon: Image },
-  { key: 'link', label: 'Link', icon: Link },
+  { key: 'file', labelKey: 'common.file', icon: File },
+  { key: 'image', labelKey: 'common.image', icon: Image },
+  { key: 'link', labelKey: 'common.link', icon: Link },
 ]
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null
@@ -86,7 +89,7 @@ function toggleFilter(key: string) {
 }
 
 function formatDate(ts: string) {
-  return new Date(ts).toLocaleDateString('en-US', {
+  return new Date(ts).toLocaleDateString(locale.value, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
@@ -105,7 +108,7 @@ function handleJump(messageId: string) {
   <Dialog :open="open" @update:open="emit('update:open', $event)">
     <DialogContent class="sm:max-w-xl max-h-[80vh] flex flex-col">
       <DialogHeader>
-        <DialogTitle>Search Messages</DialogTitle>
+        <DialogTitle>{{ $t('chat.searchMessagesTitle') }}</DialogTitle>
       </DialogHeader>
 
       <div class="space-y-3">
@@ -114,7 +117,7 @@ function handleJump(messageId: string) {
           <Search class="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             v-model="query"
-            placeholder="Search messages..."
+            :placeholder="$t('chat.searchPlaceholder')"
             class="pl-10"
             autofocus
           />
@@ -134,7 +137,7 @@ function handleJump(messageId: string) {
             ]"
           >
             <component :is="f.icon" class="h-3 w-3" />
-            {{ f.label }}
+            {{ $t(f.labelKey) }}
           </button>
         </div>
       </div>
@@ -143,17 +146,17 @@ function handleJump(messageId: string) {
       <ScrollArea class="flex-1 min-h-0 mt-3">
         <div class="space-y-2 pr-2">
           <div v-if="isSearching" class="flex items-center justify-center py-8">
-            <span class="text-sm text-muted-foreground">Searching...</span>
+            <span class="text-sm text-muted-foreground">{{ $t('chat.searching') }}</span>
           </div>
 
           <div v-else-if="hasSearched && results.length === 0" class="flex flex-col items-center justify-center py-8">
             <Search class="mb-2 h-8 w-8 text-muted-foreground/30" />
-            <p class="text-sm text-muted-foreground">No results found</p>
+            <p class="text-sm text-muted-foreground">{{ $t('common.noResults') }}</p>
           </div>
 
           <template v-else>
             <div v-if="hasSearched && total > 0" class="mb-2 text-xs text-muted-foreground">
-              {{ total }} result{{ total !== 1 ? 's' : '' }}
+              {{ $t('chat.resultCount', total, { count: total }) }}
             </div>
 
             <button

--- a/src/components/common/OfflineBanner.vue
+++ b/src/components/common/OfflineBanner.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n'
 import { wsService } from '@/services/websocket'
 import { Button } from '@/components/ui/button'
 import { WifiOff, X } from 'lucide-vue-next'
 
+const { t } = useI18n()
 const emit = defineEmits<{
   dismiss: []
 }>()
@@ -25,14 +27,14 @@ function retry() {
   >
     <div class="fixed inset-x-0 top-0 z-50 flex items-center justify-center gap-3 bg-destructive px-4 py-2 text-sm text-destructive-foreground shadow-lg">
       <WifiOff class="h-4 w-4 shrink-0" />
-      <span class="font-medium">Connection lost</span>
+      <span class="font-medium">{{ t('common.connectionLost') }}</span>
       <Button
         variant="outline"
         size="sm"
         class="h-7 border-destructive-foreground/30 bg-transparent text-destructive-foreground hover:bg-destructive-foreground/10"
         @click="retry"
       >
-        Retry
+        {{ t('common.retry') }}
       </Button>
       <button
         class="ml-1 rounded p-0.5 hover:bg-destructive-foreground/10"

--- a/src/components/sidebar/UserPanel.vue
+++ b/src/components/sidebar/UserPanel.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, onBeforeUnmount } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { usePresenceStore } from '@/stores/presence'
 import { useUiStore } from '@/stores/ui'
@@ -10,6 +11,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Settings, Check, Circle, MinusCircle, EyeOff } from 'lucide-vue-next'
 import type { UserStatus } from '@/types'
+
+const { t } = useI18n()
 
 const authStore = useAuthStore()
 const presenceStore = usePresenceStore()
@@ -26,10 +29,10 @@ const myStatus = computed(() =>
   authStore.user ? presenceStore.getStatus(authStore.user.id) : 'offline'
 )
 
-const statusOptions: { value: UserStatus; label: string; color: string; icon: typeof Circle }[] = [
-  { value: 'online', label: 'Online', color: 'bg-emerald-500', icon: Circle },
-  { value: 'dnd', label: 'Do Not Disturb', color: 'bg-red-500', icon: MinusCircle },
-  { value: 'offline', label: 'Invisible', color: 'bg-gray-500', icon: EyeOff },
+const statusOptions: { value: UserStatus; labelKey: string; color: string; icon: typeof Circle }[] = [
+  { value: 'online', labelKey: 'common.statusOnline', color: 'bg-emerald-500', icon: Circle },
+  { value: 'dnd', labelKey: 'common.statusDnd', color: 'bg-red-500', icon: MinusCircle },
+  { value: 'offline', labelKey: 'common.statusInvisible', color: 'bg-gray-500', icon: EyeOff },
 ]
 
 const displayStatus = computed(() => {
@@ -38,9 +41,9 @@ const displayStatus = computed(() => {
 })
 
 const statusLabel = computed(() => {
-  if (!wsConnected.value) return 'Disconnected'
+  if (!wsConnected.value) return t('common.statusDisconnected')
   const opt = statusOptions.find((o) => o.value === myStatus.value)
-  return opt?.label ?? 'Online'
+  return opt ? t(opt.labelKey) : t('common.statusOnline')
 })
 
 function setStatus(status: UserStatus) {
@@ -83,7 +86,7 @@ function openSettings() {
         </button>
       </PopoverTrigger>
       <PopoverContent v-if="wsConnected" side="top" align="start" class="w-56 p-1">
-        <div class="px-2 py-1.5 text-xs font-semibold text-muted-foreground">Set Status</div>
+        <div class="px-2 py-1.5 text-xs font-semibold text-muted-foreground">{{ $t('common.setStatus') }}</div>
         <button
           v-for="opt in statusOptions"
           :key="opt.value"
@@ -91,7 +94,7 @@ function openSettings() {
           class="flex w-full items-center gap-2.5 rounded-sm px-2 py-1.5 text-sm hover:bg-accent transition-colors"
         >
           <span :class="['h-2.5 w-2.5 rounded-full shrink-0', opt.color]" />
-          <span class="flex-1">{{ opt.label }}</span>
+          <span class="flex-1">{{ $t(opt.labelKey) }}</span>
           <Check v-if="myStatus === opt.value" class="h-4 w-4 text-primary shrink-0" />
         </button>
       </PopoverContent>
@@ -108,7 +111,7 @@ function openSettings() {
               <Settings class="h-4 w-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent>Settings</TooltipContent>
+          <TooltipContent>{{ $t('nav.settings') }}</TooltipContent>
         </Tooltip>
       </div>
     </TooltipProvider>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -18,7 +18,16 @@
     "useBackupCode": "Use a backup code",
     "enterBackupCode": "Enter backup code",
     "verify": "Verify",
-    "backToLogin": "Back to login"
+    "backToLogin": "Back to login",
+    "emailVerificationRequired": "Email verification required",
+    "verifyEmailSubtitle": "Please verify your email address to unlock all features.",
+    "verificationEmailSent": "Verification email sent! Please check your inbox.",
+    "pleaseWaitBeforeResend": "Please wait before requesting another email.",
+    "tooManyRequests": "Too many requests. Please try again later.",
+    "failedSendVerification": "Failed to send verification email. Please try again.",
+    "sending": "Sending...",
+    "waitCooldown": "Wait {time}",
+    "resendEmail": "Resend Email"
   },
   "nav": {
     "settings": "Settings",
@@ -64,7 +73,14 @@
     "failedUnpin": "Failed to unpin message",
     "addReaction": "Add Reaction",
     "channelNotFound": "Channel not found",
-    "userMentionClicked": "User: {username}"
+    "userMentionClicked": "User: {username}",
+    "searchMessagesTitle": "Search Messages",
+    "searchPlaceholder": "Search messages...",
+    "searching": "Searching...",
+    "resultCount": "{count} result | {count} results",
+    "pinHint": "Pin important messages to find them later",
+    "jump": "Jump",
+    "unpin": "Unpin"
   },
   "settings": {
     "myAccount": "My Account",
@@ -435,6 +451,15 @@
     "yes": "Yes",
     "no": "No",
     "or": "or",
-    "and": "and"
+    "and": "and",
+    "connectionLost": "Connection lost",
+    "statusOnline": "Online",
+    "statusDnd": "Do Not Disturb",
+    "statusInvisible": "Invisible",
+    "statusDisconnected": "Disconnected",
+    "setStatus": "Set Status",
+    "file": "File",
+    "image": "Image",
+    "link": "Link"
   }
 }

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -18,7 +18,16 @@
     "useBackupCode": "Använd en reservkod",
     "enterBackupCode": "Ange reservkod",
     "verify": "Verifiera",
-    "backToLogin": "Tillbaka till inloggning"
+    "backToLogin": "Tillbaka till inloggning",
+    "emailVerificationRequired": "E-postverifiering krävs",
+    "verifyEmailSubtitle": "Verifiera din e-postadress för att låsa upp alla funktioner.",
+    "verificationEmailSent": "Verifieringsmail skickat! Kolla din inkorg.",
+    "pleaseWaitBeforeResend": "Vänta innan du begär ett nytt mail.",
+    "tooManyRequests": "För många förfrågningar. Försök igen senare.",
+    "failedSendVerification": "Kunde inte skicka verifieringsmail. Försök igen.",
+    "sending": "Skickar...",
+    "waitCooldown": "Vänta {time}",
+    "resendEmail": "Skicka om mail"
   },
   "nav": {
     "settings": "Inställningar",
@@ -64,7 +73,14 @@
     "failedUnpin": "Kunde inte lossa meddelande",
     "addReaction": "Lägg till reaktion",
     "channelNotFound": "Kanal hittades inte",
-    "userMentionClicked": "Användare: {username}"
+    "userMentionClicked": "Användare: {username}",
+    "searchMessagesTitle": "Sök meddelanden",
+    "searchPlaceholder": "Sök meddelanden...",
+    "searching": "Söker...",
+    "resultCount": "{count} resultat | {count} resultat",
+    "pinHint": "Fäst viktiga meddelanden för att hitta dem senare",
+    "jump": "Hoppa till",
+    "unpin": "Lossa"
   },
   "settings": {
     "myAccount": "Mitt konto",
@@ -418,6 +434,15 @@
     "yes": "Ja",
     "no": "Nej",
     "or": "eller",
-    "and": "och"
+    "and": "och",
+    "connectionLost": "Anslutning förlorad",
+    "statusOnline": "Online",
+    "statusDnd": "Stör ej",
+    "statusInvisible": "Osynlig",
+    "statusDisconnected": "Frånkopplad",
+    "setStatus": "Ange status",
+    "file": "Fil",
+    "image": "Bild",
+    "link": "Länk"
   }
 }


### PR DESCRIPTION
Fixes the i18n gaps identified in #222 by extracting all hardcoded English strings from the remaining components into the locale files.

## Changes

- `EmailVerificationBanner.vue` — 9 strings extracted to `auth` namespace
- `OfflineBanner.vue` — uses `common.connectionLost` and `common.retry`
- `SearchModal.vue` — title, placeholder, filter labels, result count (with pluralization), locale-aware date formatting
- `UserPanel.vue` — status labels, "Set Status" heading, Settings tooltip
- `ChatHeader.vue` — Search, Pinned Messages, Toggle Member List tooltips
- `PinnedMessagesPanel.vue` — Loading, pin hint, Jump, Unpin buttons; locale-aware date formatting
- 26 new keys added to both `en.json` and `sv.json`
- `CLAUDE.md` updated with i18n requirements to prevent future regressions

Closes #222

Generated with [Claude Code](https://claude.ai/code)